### PR TITLE
Avoid truncating read name

### DIFF
--- a/kseq.h
+++ b/kseq.h
@@ -179,7 +179,7 @@ typedef struct __kstring_t {
 			seq->last_char = c; \
 		} /* else: the first header char has been read in the previous call */ \
 		seq->comment.l = seq->seq.l = seq->qual.l = 0; /* reset all members */ \
-		if (ks_getuntil(ks, 0, &seq->name, &c) < 0) return -1; /* normal exit: EOF */ \
+		if (ks_getuntil(ks, KS_SEP_LINE, &seq->name, &c) < 0) return -1; /* normal exit: EOF */ \
 		if (c != '\n') ks_getuntil(ks, KS_SEP_LINE, &seq->comment, 0); /* read FASTA/Q comment */ \
 		if (seq->seq.s == 0) { /* we can do this in the loop below, but that is slower */ \
 			seq->seq.m = 256; \


### PR DESCRIPTION
**Issue:** Read names are truncated by `trimadap-mt` when the read name contains whitespace
**Fix:** Use `KS_SEP_LINE` rather than `KS_SEP_SPACE`

I hope this is correct way to fix this issue.

## Example data

```
$ fastq-dump -X 1 --readids -Z SRR891268
Read 1 spots for SRR891268
Written 1 spots for SRR891268
@SRR891268.1 HWI-ST281:266:C1LTTACXX:1:1101:1238:1978 length=100
NTCGGGAGGATCCTATTGGTGCGGGGGCTTTGTATGATTATGGGCGTTGAACCTATTCCCCCGAGCAATCTCAATTACAATATATACACCAACAAACAAT
+SRR891268.1 HWI-ST281:266:C1LTTACXX:1:1101:1238:1978 length=100
#1:BDD?DH<AAFF@GGGIEHACFHII?DFEEE;@D6@C>ACDD(8?BD#11:ABDEA==CFFBBBBCCA?ECEFI?::CC?CBGBFDGHIJJGHGIHHG
```

## Current behaviour

Read name is truncated on line 1

```
$ fastq-dump -X 1 --readids -Z SRR891268 | trimadap-mt
Read 1 spots for SRR891268
Written 1 spots for SRR891268
@SRR891268.1
NTCGGGAGGATCCTATTGGTGCGGGGGCTTTGTATGATTATGGGCGTTGAACCTATTCCCCCGAGCAATCTCAATTACAATATATACACCAACAAACAAT
+
#1:BDD?DH<AAFF@GGGIEHACFHII?DFEEE;@D6@C>ACDD(8?BD#11:ABDEA==CFFBBBBCCA?ECEFI?::CC?CBGBFDGHIJJGHGIHHG
0               AATGATACGGCGACCACCGAGATCTACACTCTTTCCCTACACGACGCTCTTCCGATCT
0               AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC
0               AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGTAGATCTCGGTGGTCGCCGTATCATT
0               ATCTCGTATGCCGTCTTCTGCTTG
```

## Patch behaviour

Full read name returned on line 1

```
$ fastq-dump -X 1 --readids -Z SRR891268 | trimadap-mt
Read 1 spots for SRR891268
Written 1 spots for SRR891268
@SRR891268.1 HWI-ST281:266:C1LTTACXX:1:1101:1238:1978 length=100
NTCGGGAGGATCCTATTGGTGCGGGGGCTTTGTATGATTATGGGCGTTGAACCTATTCCCCCGAGCAATCTCAATTACAATATATACACCAACAAACAAT
+
#1:BDD?DH<AAFF@GGGIEHACFHII?DFEEE;@D6@C>ACDD(8?BD#11:ABDEA==CFFBBBBCCA?ECEFI?::CC?CBGBFDGHIJJGHGIHHG
0               AATGATACGGCGACCACCGAGATCTACACTCTTTCCCTACACGACGCTCTTCCGATCT
0               AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC
0               AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGTAGATCTCGGTGGTCGCCGTATCATT
0               ATCTCGTATGCCGTCTTCTGCTTG
```